### PR TITLE
Add PBRTWrapper for local PBRT execution

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,21 @@
+# Python utilities for ISET3d
+
+This package provides small helpers for invoking PBRT from Python.
+
+## Using a local PBRT installation
+
+You can render scenes directly with a locally installed PBRT binary without
+Docker.  The `PBRTWrapper` class only needs the path to your PBRT executable:
+
+```python
+from iset3d.python import PBRTWrapper
+
+wrapper = PBRTWrapper("/usr/local/bin/pbrt")
+wrapper.run("scene.pbrt", "output.exr")
+```
+
+## Using Docker
+
+The optional `DockerWrapper` relies on the local Docker installation to run PBRT
+inside a container.  If Docker is unavailable or undesired, use
+`PBRTWrapper` as shown above.

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -1,0 +1,5 @@
+"""Simple helpers for working with PBRT."""
+
+from .pbrt_wrapper import PBRTWrapper
+
+__all__ = ["PBRTWrapper"]

--- a/python/pbrt_wrapper.py
+++ b/python/pbrt_wrapper.py
@@ -1,0 +1,31 @@
+import subprocess
+from pathlib import Path
+
+class PBRTWrapper:
+    """Simple wrapper to run the local PBRT executable."""
+
+    def __init__(self, pbrt_path="pbrt"):
+        self.pbrt_path = str(pbrt_path)
+
+    def run(self, scene_file, output_file, extra_args=None, check=True):
+        """Run PBRT on a .pbrt scene file and generate an EXR result.
+
+        Parameters
+        ----------
+        scene_file : str or Path
+            Path to the input .pbrt scene description.
+        output_file : str or Path
+            Destination path for the rendered EXR file.
+        extra_args : list, optional
+            Additional command line arguments to pass to PBRT.
+        check : bool
+            If True, ``subprocess.run`` will raise ``CalledProcessError`` on
+            failure.
+        """
+        scene_file = str(scene_file)
+        output_file = str(output_file)
+        cmd = [self.pbrt_path, "--outfile", output_file]
+        if extra_args:
+            cmd.extend(extra_args)
+        cmd.append(scene_file)
+        return subprocess.run(cmd, check=check)

--- a/python/tests/test_pbrt_wrapper.py
+++ b/python/tests/test_pbrt_wrapper.py
@@ -1,0 +1,20 @@
+import sys
+import os
+import subprocess
+from unittest import mock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+from python import PBRTWrapper
+
+
+def test_run_invokes_subprocess():
+    wrapper = PBRTWrapper('/path/to/pbrt')
+    with mock.patch('subprocess.run') as m_run:
+        wrapper.run('scene.pbrt', 'out.exr')
+        m_run.assert_called_with([
+            '/path/to/pbrt',
+            '--outfile',
+            'out.exr',
+            'scene.pbrt'
+        ], check=True)
+


### PR DESCRIPTION
## Summary
- add `PBRTWrapper` class for running PBRT locally
- export new class from package
- document local PBRT usage
- add simple unit test for wrapper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68423e6fd064832389f40b38cd3f8f41