### PR TITLE
Add local PBRT wrapper for Python port

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@ To see some examples, have a look at the tutorial directory. If you want to read
 Note: This repository was formerly ISET3d-v4, pbrt2iset, and before that we relied on RenderToolbox4.
 
 ISET3d was originally developed in Brian Wandell's [Vistalab group](https://vistalab.stanford.edu/) at [Stanford University](stanford.edu), along with co-contributors from other research institutions and industry.
+
+## Experimental Python Port
+
+A very small subset of ISET3d is being reimplemented in Python under the `python/` directory. This effort is experimental and currently provides only basic recipe management and a simple Docker wrapper.

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,30 @@
+# Python port (experimental)
+
+This directory contains an early, **experimental** effort to
+re-implement portions of the MATLAB based ISET3d toolbox in
+Python. The implementation is currently very limited and only
+includes a minimal ``Recipe`` data structure and utilities to run
+PBRT either through Docker or directly on the local system.
+
+``DockerWrapper`` relies on the local Docker installation and does
+not yet support remote execution. Usage::
+
+    from iset3d.python import Recipe, DockerWrapper
+
+    recipe = Recipe(name="ChessSet")
+    recipe.set("integrator", {"type": "path"})
+    recipe.save("ChessSet.json")
+
+    dw = DockerWrapper()
+    dw.run("/path/to/ChessSet.pbrt", "ChessSet.exr")
+
+Alternatively, if you have a local PBRT binary installed you can
+use ``PBRTWrapper``::
+
+    from iset3d.python import PBRTWrapper
+
+    pw = PBRTWrapper(pbrt_path="/opt/pbrt/pbrt")
+    pw.run("/path/to/ChessSet.pbrt", "ChessSet.exr")
+
+Expect many missing features. Contributions welcome!
+

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -1,0 +1,14 @@
+"""ISET3d Python migration package (partial).
+
+This is a preliminary Python port of certain components of
+ISET3d's MATLAB code base. Functionality is currently very
+limited and provided for demonstration and experimentation
+purposes only.
+"""
+
+from .recipe import Recipe
+from .docker_wrapper import DockerWrapper
+from .pbrt_wrapper import PBRTWrapper
+from . import utils
+
+__all__ = ["Recipe", "DockerWrapper", "PBRTWrapper", "utils"]

--- a/python/docker_wrapper.py
+++ b/python/docker_wrapper.py
@@ -1,0 +1,41 @@
+"""Docker wrapper utilities for PBRT rendering."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class DockerWrapper:
+    """Manage local or remote PBRT docker invocations."""
+
+    image: str = "digitalprodev/pbrt-v4-gpu:latest"
+    work_dir: Optional[str] = None
+    gpu: bool = True
+    verbosity: int = 1
+
+    def run(
+        self, scene_path: str, output_exr: str
+    ) -> subprocess.CompletedProcess:
+        """Run PBRT via docker."""
+        cmd = [
+            "docker",
+            "run",
+            "--rm",
+            "-v",
+            f"{os.path.abspath(scene_path)}:/scene:ro",
+            self.image,
+            "pbrt",
+            "--outfile",
+            output_exr,
+            os.path.basename(scene_path),
+        ]
+        if self.gpu:
+            cmd.insert(2, "--gpus")
+            cmd.insert(3, "all")
+        if self.verbosity:
+            print("Running:", " ".join(cmd))
+        return subprocess.run(cmd, capture_output=True, text=True)

--- a/python/pbrt_wrapper.py
+++ b/python/pbrt_wrapper.py
@@ -1,0 +1,33 @@
+"""Local PBRT execution utilities."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class PBRTWrapper:
+    """Run PBRT directly without Docker."""
+
+    pbrt_path: str = "pbrt"
+    work_dir: Optional[str] = None
+    verbosity: int = 1
+
+    def run(
+        self, scene_path: str, output_exr: str
+    ) -> subprocess.CompletedProcess:
+        """Execute PBRT on the local system."""
+        scene_path = os.path.abspath(scene_path)
+        output_exr = os.path.abspath(output_exr)
+        cmd = [self.pbrt_path, "--outfile", output_exr, scene_path]
+        if self.verbosity:
+            print("Running:", " ".join(cmd))
+        return subprocess.run(
+            cmd,
+            cwd=self.work_dir or os.path.dirname(scene_path),
+            capture_output=True,
+            text=True,
+        )

--- a/python/recipe.py
+++ b/python/recipe.py
@@ -1,0 +1,39 @@
+"""Simplified Recipe data structure."""
+
+from dataclasses import dataclass, field
+from typing import Dict, Any
+
+
+@dataclass
+class Recipe:
+    """Simplified representation of a PBRT recipe."""
+
+    name: str = "recipe"
+    parameters: Dict[str, Any] = field(default_factory=dict)
+
+    def get(self, key: str, default=None):
+        """Return a parameter value."""
+        return self.parameters.get(key, default)
+
+    def set(self, key: str, value):
+        """Set a parameter value."""
+        self.parameters[key] = value
+
+    def save(self, path: str) -> None:
+        """Serialize the recipe to JSON."""
+        import json
+
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(
+                {"name": self.name, "parameters": self.parameters}, f, indent=2
+            )
+
+    @staticmethod
+    def load(path: str) -> "Recipe":
+        import json
+
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        r = Recipe(name=data.get("name", "recipe"))
+        r.parameters.update(data.get("parameters", {}))
+        return r

--- a/python/tests/test_pbrt_wrapper.py
+++ b/python/tests/test_pbrt_wrapper.py
@@ -1,0 +1,20 @@
+import os
+import sys
+from unittest import mock
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+)
+from python.pbrt_wrapper import PBRTWrapper
+
+
+def test_run_invokes_subprocess():
+    wrapper = PBRTWrapper(pbrt_path="pbrt", verbosity=0)
+    with mock.patch("subprocess.run") as run_mock:
+        wrapper.run("scene.pbrt", "out.exr")
+        run_mock.assert_called()
+        args = run_mock.call_args[0][0]
+        assert args[0] == "pbrt"
+        assert "--outfile" in args
+        assert os.path.abspath("out.exr") in args
+        assert os.path.abspath("scene.pbrt") in args

--- a/python/utils.py
+++ b/python/utils.py
@@ -1,0 +1,8 @@
+"""Utility helpers."""
+
+import os
+
+
+def pi_root_path() -> str:
+    """Return repository root path."""
+    return os.path.dirname(os.path.abspath(os.path.join(__file__, os.pardir)))


### PR DESCRIPTION
## Summary
- implement `PBRTWrapper` for calling a locally installed PBRT binary
- export the new wrapper from the Python package
- document local execution usage in `python/README.md`
- provide a unit test covering the wrapper

## Testing
- `black python --line-length 79`
- `python -m py_compile python/*.py python/tests/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68423acc7f648323b4fec54179d7304d