### PR TITLE
Add Python Recipe class

### DIFF
--- a/iset3d/__init__.py
+++ b/iset3d/__init__.py
@@ -1,5 +1,6 @@
 """Utilities for interacting with PBRT."""
 
 from .pbrt_wrapper import PBRTWrapper
+from .recipe import Recipe
 
-__all__ = ["PBRTWrapper"]
+__all__ = ["PBRTWrapper", "Recipe"]

--- a/iset3d/recipe.py
+++ b/iset3d/recipe.py
@@ -1,0 +1,70 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+
+def _normalize(key: str) -> str:
+    """Normalize parameter names for comparison."""
+    return key.lower().replace(' ', '').replace('_', '')
+
+
+@dataclass
+class Recipe:
+    """Container for PBRT recipe data."""
+
+    name: str = 'recipe'
+    camera: Any = None
+    sampler: Any = None
+    film: Any = None
+    filter: Any = None
+    integrator: Any = None
+    renderer: Any = None
+    lookAt: Any = None
+    scale: Any = None
+    world: Any = None
+    lights: Any = None
+    transformTimes: Any = None
+
+    inputFile: str = ''
+    outputFile: str = ''
+    renderedFile: str = ''
+    version: int = 4
+
+    materials: Dict[str, Any] = field(
+        default_factory=lambda: {'list': {}, 'order': [], 'lib': None}
+    )
+    textures: Any = None
+    assets: Any = None
+    exporter: str = ''
+    media: Dict[str, Any] = field(
+        default_factory=lambda: {'list': {}, 'order': [], 'lib': None}
+    )
+    metadata: Any = None
+    recipeVer: int = 2
+    hasActiveTransform: bool = False
+    verbose: int = 2
+
+    @classmethod
+    def create(cls, **kwargs) -> "Recipe":
+        """Factory returning a recipe with default values."""
+        return cls(**kwargs)
+
+    def _match_attr(self, key: str) -> str:
+        norm = _normalize(key)
+        for attr in self.__dict__:
+            if _normalize(attr) == norm:
+                return attr
+        raise AttributeError(f"Unknown parameter: {key}")
+
+    def get(self, param: str, default: Any = None) -> Any:
+        """Retrieve a parameter value."""
+        try:
+            attr = self._match_attr(param)
+        except AttributeError:
+            return default
+        return getattr(self, attr)
+
+    def set(self, param: str, value: Any) -> "Recipe":
+        """Set a parameter value."""
+        attr = self._match_attr(param)
+        setattr(self, attr, value)
+        return self

--- a/python/tests/test_recipe.py
+++ b/python/tests/test_recipe.py
@@ -1,0 +1,22 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+from iset3d import Recipe
+
+
+def test_defaults():
+    r = Recipe()
+    assert r.name == 'recipe'
+    assert r.version == 4
+    assert r.materials['list'] == {}
+    assert r.media['order'] == []
+
+
+def test_get_set():
+    r = Recipe()
+    r.set('input file', 'scene.pbrt')
+    assert r.get('input file') == 'scene.pbrt'
+    r.set('camera', {'type': 'pinhole'})
+    assert r.get('camera')['type'] == 'pinhole'


### PR DESCRIPTION
## Summary
- expose `Recipe` in `iset3d` package
- implement `iset3d.recipe` with defaults mirroring MATLAB class
- test Recipe defaults and getter/setter helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843fdc432ac832389c85e34324e61a3