### PR TITLE
Add Python example and tests

### DIFF
--- a/examples/simple_render.py
+++ b/examples/simple_render.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from iset3d import Recipe, PBRTWrapper
+
+
+def main(output_file='simple_render.exr'):
+    """Render the SimpleScene example using PBRTWrapper."""
+    # Prepare recipe information
+    scene_file = Path('data/scenes/SimpleScene/SimpleScene.pbrt')
+    recipe = Recipe.create(name='SimpleScene')
+    recipe.set('input file', scene_file)
+    recipe.set('output file', output_file)
+
+    # Run PBRT to render the scene
+    wrapper = PBRTWrapper('pbrt')
+    wrapper.run(str(scene_file), str(output_file))
+
+    recipe.set('rendered file', output_file)
+    print(f"Rendered {recipe.get('name')} to {recipe.get('rendered file')}")
+    return Path(output_file)
+
+
+if __name__ == '__main__':
+    main()

--- a/python/tests/test_examples.py
+++ b/python/tests/test_examples.py
@@ -1,0 +1,21 @@
+import os
+import sys
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+from examples import simple_render
+from iset3d import PBRTWrapper
+
+
+def test_simple_render_creates_output(tmp_path):
+    output = tmp_path / 'result.exr'
+
+    def fake_run(self, scene_file, out_file, extra_args=None, check=True):
+        Path(out_file).write_text('dummy')
+        return mock.MagicMock()
+
+    with mock.patch.object(PBRTWrapper, 'run', new=fake_run):
+        result_path = simple_render.main(output_file=str(output))
+        assert result_path.exists()


### PR DESCRIPTION
## Summary
- add `examples/simple_render.py` replicating MATLAB rendering logic using `Recipe` and `PBRTWrapper`
- new pytest ensuring the example creates output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844485bb4488323bc2774c4276a332a