### PR TITLE
Fix README import path for PBRTWrapper

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -8,7 +8,7 @@ You can render scenes directly with a locally installed PBRT binary without
 Docker.  The `PBRTWrapper` class only needs the path to your PBRT executable:
 
 ```python
-from iset3d.python import PBRTWrapper
+from iset3d import PBRTWrapper
 
 wrapper = PBRTWrapper("/usr/local/bin/pbrt")
 wrapper.run("scene.pbrt", "output.exr")


### PR DESCRIPTION
## Summary
- update Python README example to import PBRTWrapper from the `iset3d` package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a083c9008323a619519ac6f9d5a6