### PR TITLE
Fix setuptools package discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,6 @@ dependencies = [
     "imageio",
 ]
 
+[tool.setuptools.packages.find]
+where = ["."]
+


### PR DESCRIPTION
## Summary
- configure setuptools to look for packages from repo root

## Testing
- `python -m build --wheel`


------
https://chatgpt.com/codex/tasks/task_e_6844a30aa28483239201545dd91ae2d1