### PR TITLE
Enhance Recipe helpers

### DIFF
--- a/iset3d/recipe.py
+++ b/iset3d/recipe.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from typing import Any, Dict
+from pathlib import Path
 
 
 def _normalize(key: str) -> str:
@@ -21,7 +22,7 @@ class Recipe:
     lookAt: Any = None
     scale: Any = None
     world: Any = None
-    lights: Any = None
+    lights: Dict[str, Any] = field(default_factory=dict)
     transformTimes: Any = None
 
     inputFile: str = ''
@@ -43,6 +44,21 @@ class Recipe:
     hasActiveTransform: bool = False
     verbose: int = 2
 
+    # Mappings for commonly used aliases in get/set
+    _GET_ALIASES = {
+        'inputbasename': lambda self: Path(self.inputFile).stem,
+        'inputdir': lambda self: str(Path(self.inputFile).parent),
+        'outputbasename': lambda self: Path(self.outputFile).stem,
+        'outputdir': lambda self: str(Path(self.outputFile).parent),
+    }
+
+    _SET_ALIASES = {
+        'inputfile': 'inputFile',
+        'outputfile': 'outputFile',
+        'renderedfile': 'renderedFile',
+        'lookat': 'lookAt',
+    }
+
     @classmethod
     def create(cls, **kwargs) -> "Recipe":
         """Factory returning a recipe with default values."""
@@ -50,6 +66,9 @@ class Recipe:
 
     def _match_attr(self, key: str) -> str:
         norm = _normalize(key)
+        alias = self._SET_ALIASES.get(norm)
+        if isinstance(alias, str):
+            return alias
         for attr in self.__dict__:
             if _normalize(attr) == norm:
                 return attr
@@ -57,6 +76,10 @@ class Recipe:
 
     def get(self, param: str, default: Any = None) -> Any:
         """Retrieve a parameter value."""
+        norm = _normalize(param)
+        if norm in self._GET_ALIASES:
+            func = self._GET_ALIASES[norm]
+            return func(self)
         try:
             attr = self._match_attr(param)
         except AttributeError:
@@ -65,6 +88,36 @@ class Recipe:
 
     def set(self, param: str, value: Any) -> "Recipe":
         """Set a parameter value."""
+        norm = _normalize(param)
+        if norm in self._SET_ALIASES:
+            param = self._SET_ALIASES[norm]
         attr = self._match_attr(param)
         setattr(self, attr, value)
         return self
+
+    # Convenience methods for lights and materials
+    def add_light(self, name: str, data: Any) -> "Recipe":
+        self.lights[name] = data
+        return self
+
+    def remove_light(self, name: str) -> "Recipe":
+        self.lights.pop(name, None)
+        return self
+
+    def get_light(self, name: str, default: Any = None) -> Any:
+        return self.lights.get(name, default)
+
+    def add_material(self, name: str, data: Any) -> "Recipe":
+        self.materials['list'][name] = data
+        if name not in self.materials['order']:
+            self.materials['order'].append(name)
+        return self
+
+    def remove_material(self, name: str) -> "Recipe":
+        self.materials['list'].pop(name, None)
+        if name in self.materials['order']:
+            self.materials['order'].remove(name)
+        return self
+
+    def get_material(self, name: str, default: Any = None) -> Any:
+        return self.materials['list'].get(name, default)

--- a/python/tests/test_recipe.py
+++ b/python/tests/test_recipe.py
@@ -20,3 +20,24 @@ def test_get_set():
     assert r.get('input file') == 'scene.pbrt'
     r.set('camera', {'type': 'pinhole'})
     assert r.get('camera')['type'] == 'pinhole'
+
+
+def test_synonyms():
+    r = Recipe()
+    r.set('inputfile', 'scene.pbrt')
+    assert r.get('input file') == 'scene.pbrt'
+    r.set('outputfile', '/tmp/out.pbrt')
+    assert r.get('output dir') == '/tmp'
+
+
+def test_convenience_methods():
+    r = Recipe()
+    r.add_light('main', {'type': 'point'})
+    assert r.get_light('main')['type'] == 'point'
+    r.remove_light('main')
+    assert r.get_light('main') is None
+
+    r.add_material('matte', {'kd': [1, 1, 1]})
+    assert r.get_material('matte')['kd'] == [1, 1, 1]
+    r.remove_material('matte')
+    assert r.get_material('matte') is None


### PR DESCRIPTION
## Summary
- improve `recipe.py` with alias support for get/set
- add helper methods to manage lights and materials
- test new capabilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a5b1ce0083239dafcda1e89d9cf8