### PR TITLE
Add camera intro example and test

### DIFF
--- a/examples/pi_intro_camera.py
+++ b/examples/pi_intro_camera.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+from iset3d import Recipe, PBRTWrapper
+
+
+def main(pinhole_file='camera_pinhole.exr', omni_file='camera_omni.exr'):
+    """Approximate the t_piIntro_camera tutorial using PBRTWrapper.
+
+    Two renders are produced: one using a pinhole camera and one using an
+    omni camera with a lens file.  The function returns the path to the
+    final render (the omni camera image).
+    """
+
+    # Create recipe for the SimpleScene example
+    scene_file = Path('data/scenes/SimpleScene/SimpleScene.pbrt')
+    recipe = Recipe.create(name='SimpleScene')
+    recipe.set('input file', scene_file)
+
+    # Configure initial pinhole camera parameters
+    recipe.set('output file', pinhole_file)
+
+    # Lights: remove defaults and add a skymap
+    for light in ['MoonLight', 'Sky1', 'Sunlight']:
+        recipe.remove_light(light)
+    recipe.add_light('room_L', {
+        'type': 'infinite',
+        'mapname': 'room.exr',
+        'specscale': 2000
+    })
+
+    wrapper = PBRTWrapper('pbrt')
+
+    # First render with pinhole camera
+    wrapper.run(str(scene_file), str(pinhole_file))
+    recipe.set('rendered file', pinhole_file)
+    print(f"Rendered pinhole camera to {pinhole_file}")
+
+    # Switch to omni camera with lens
+    lensfile = 'dgauss.22deg.6.0mm.json'
+    recipe.set('camera', {'type': 'omni', 'lensfile': lensfile})
+    recipe.set('output file', omni_file)
+
+    wrapper.run(str(scene_file), str(omni_file))
+    recipe.set('rendered file', omni_file)
+    print(f"Rendered omni camera using {lensfile} to {omni_file}")
+    return Path(omni_file)
+
+
+if __name__ == '__main__':
+    main()

--- a/python/tests/test_intro_camera.py
+++ b/python/tests/test_intro_camera.py
@@ -1,0 +1,22 @@
+import os
+import sys
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+from examples import pi_intro_camera
+from iset3d import PBRTWrapper
+
+
+def test_pi_intro_camera_creates_output(tmp_path):
+    pinhole = tmp_path / 'pinhole.exr'
+    omni = tmp_path / 'omni.exr'
+
+    def fake_run(self, scene_file, out_file, extra_args=None, check=True):
+        Path(out_file).write_text('dummy')
+        return mock.MagicMock()
+
+    with mock.patch.object(PBRTWrapper, 'run', new=fake_run):
+        result = pi_intro_camera.main(pinhole_file=str(pinhole), omni_file=str(omni))
+        assert result.exists()


### PR DESCRIPTION
## Summary
- add `pi_intro_camera.py` example porting the MATLAB tutorial
- test that the example creates an output file when PBRT is mocked

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684507716e788323934761bf3d9e96ab