### PR TITLE
Remove Docker wrapper doc section

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -14,8 +14,3 @@ wrapper = PBRTWrapper("/usr/local/bin/pbrt")
 wrapper.run("scene.pbrt", "output.exr")
 ```
 
-## Using Docker
-
-The optional `DockerWrapper` relies on the local Docker installation to run PBRT
-inside a container.  If Docker is unavailable or undesired, use
-`PBRTWrapper` as shown above.


### PR DESCRIPTION
## Summary
- remove the unused DockerWrapper section from the Python README

## Testing
- `pytest -q python/tests`

------
https://chatgpt.com/codex/tasks/task_e_68450b174b048323b99697b833eaa644