### PR TITLE
Add sample scenes to package

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@
 
 This repository, ISET3d, was very useful, but it became bloated - in large part because we kept adding PBRT scenes (but also other reasons).  Zhenyi Liu slimmed it down into [ISET3d-tiny](https://github.com/ISET/iset3d-tiny).  The basic ideas and methods are implemented there.  A bit better.
 
-We moved the PBRT scene data to the [Stanford digital repository](https://purl.stanford.edu/cb706yg0989). When the user wants to render one of those scenes, it is downloaded by a method to a directory in ISET3d-tiny that is 'gitignored'. 
+We moved the PBRT scene data to the [Stanford digital repository](https://purl.stanford.edu/cb706yg0989). When the user wants to render one of those scenes, it is downloaded by a method to a directory in ISET3d-tiny that is 'gitignored'.
+
+Only a handful of small scenes remain in this repository so that the Python
+examples run without any additional downloads. These are installed with the
+Python package under ``iset3d/data/scenes`` and include ``SimpleScene``,
+``MacBethChecker`` and ``CornellBoxReference`` along with a sample lens file in
+``testplane``.
 
 We have most of the isetvalidation for iset3d-tiny inplace.
 
@@ -28,6 +34,21 @@ The general approach is the following
  * Write a new set of modified PBRT files and render them into an ISETCam scene or optical image (oi).
 
 To see some examples, have a look at the tutorial directory. If you want to read more, please look through the [wiki pages](https://github.com/ISET/iset3d/wiki)
+
+## Accessing the packaged scenes
+
+When installed via ``pip`` the sample scenes are included inside the
+``iset3d`` package.  You can locate them using ``importlib.resources``:
+
+```python
+from importlib import resources
+scene = resources.files("iset3d").joinpath(
+    "data/scenes/SimpleScene/SimpleScene.pbrt"
+)
+```
+
+The example scripts in ``examples/`` expect the scene files to be
+available at these locations.
 
 Note: This repository was formerly ISET3d-v4, pbrt2iset, and before that we relied on RenderToolbox4.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,4 +18,16 @@ dependencies = []
 
 [tool.setuptools.packages.find]
 where = ["."]
+exclude = [
+    "data*",
+    "examples*",
+]
+
+[tool.setuptools.package-data]
+"" = [
+    "data/scenes/SimpleScene/**",
+    "data/scenes/MacBethChecker/**",
+    "data/scenes/CornellBoxReference/**",
+    "data/scenes/testplane/dgauss.22deg.3.0mm.json",
+]
 

--- a/python/README.md
+++ b/python/README.md
@@ -14,3 +14,13 @@ wrapper = PBRTWrapper("/usr/local/bin/pbrt")
 wrapper.run("scene.pbrt", "output.exr")
 ```
 
+## Sample data
+
+The Python package installs a few small scenes so that the examples work
+out of the box.  They can be located with ``importlib.resources``:
+
+```python
+from importlib import resources
+simple = resources.files("iset3d").joinpath("data/scenes/SimpleScene")
+``` 
+


### PR DESCRIPTION
## Summary
- include tiny scenes as package data for the Python distribution
- document that the package contains `SimpleScene`, `MacBethChecker`, and `CornellBoxReference` scenes
- describe how to load the packaged scenes in the READMEs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845570eda1c8323b90f9b8ce236d755